### PR TITLE
fix CSV import

### DIFF
--- a/ARIEL.py
+++ b/ARIEL.py
@@ -7,9 +7,10 @@ import os
 import tensorflow as tf
 import tensorboard
 import csv
-from __future__ import absolute_import, division, print_function
-import numpy as np 
-from tensorflow import kearas
+import pandas as pd
+#from __future__ import absolute_import, division, print_function
+#import numpy as np 
+#from tensorflow import kearas
 
 ##############IF I NEED ANYTHING ELSE, ILL ADD IT#########3
 ###########################################################
@@ -19,12 +20,6 @@ from tensorflow import kearas
 #BELOW IS THE FILE IMPORT. WE ARE IMPORTING ALL FILES 
 #IN A FOLDER ====> /PATH/TO/FOLDER/*   <====ALL FILES
 
-def main():
-  fileImport()
-  learn_fn()
-  trainTest()
-main()
-
 def fileImport ():
 
   print("Eneter file path for the unstructured data.")
@@ -33,31 +28,12 @@ def fileImport ():
 
 
   #Reading the CSV
-  filenames = ["/home/hunt3r/Desktop/USData1.csv"]
+  filenames = ["/tmp/top800.csv"]
   record_defaults = [[0.0]] * 8
-  dataset = tf.data.experimental.CsvDataset(filenames, record_defaults)
-
-  
-
-def learn_fn(dataset):
-  incomeLevel = tf.feature_column.numeric_column("year")
-    
-    #defining the estimators
-    #Estimators are how
-    # 
-    # tensorflow will look at the detail. The eyes
-  ##return incomeLevel
-    ###########Training##############################
-  wordIndex(incomeLevel)
-  dataset = tf.data.Dataset.from_sparse_tensor_slices((dict(incomeLevel))
-
-
-
-trainData = keras.preprocessing.sequence.pad_sequnces(trainData, value=wordIndex["year"], padding='post', maxlen=256)
-testData = kearas.preprocessing.sequence.pad_sequences(testData, value=wrodIndex["year"], paddin='post', maxlen=256)
-len(trainData[0]) , len(testData[0])
-print(trainData[0])
-
-
-  #return trainedData.shuffle(1000).repeat()
-  print(dataset[0])
+  #Import the CSV-encoded training data with pandas for pre-processing.
+  #TODO: parse and split up the dataset in this program after importing.
+  #To encode the CSV file with only half of the dataset, do the following in a linux shell
+  #  $ head -n 800 USDaata1.csv > top800.csv
+  #  $ tail -n 800 USDaata1.csv > bottom800.csv
+  csvfix = pd.read_csv(filenames)
+  dataset = tf.data.experimental.CsvDataset(csvfix, record_defaults)


### PR DESCRIPTION
Import the CSV-encoded training data with pandas for pre-processing.
To encode the CSV file with only half of the dataset, do the following in a linux shell
TODO: parse and split up the dataset in this program after importing.